### PR TITLE
:lipstick: Style: programmingPageStyle

### DIFF
--- a/src/Components/Footer/footer.styled.jsx
+++ b/src/Components/Footer/footer.styled.jsx
@@ -1,12 +1,12 @@
 import styled from 'styled-components';
 
 export const FooterContainer = styled.footer`
-  /* position: fixed;
+  position: fixed;
   bottom: 0;
-  left: 0; */
+  left: 0;
 
   width: 100%;
-  height: 150px;
+  height: 100px;
   background-color: #697077;
   text-align: center;
   display: flex;

--- a/src/Components/Header/Header.jsx
+++ b/src/Components/Header/Header.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { HeaderContainer, SearchBarWrapper } from './header.styled';
 import { useSetRecoilState } from 'recoil';
 import { searchResultState } from '../../Recoil/searchResultState';
@@ -11,6 +11,8 @@ export default function Header({ type }) {
   const [error, setError] = useState(null);
   const setSearchResult = useSetRecoilState(searchResultState);
   const navigate = useNavigate();
+
+  const [scrolling, setScrolling] = useState(false);
 
   const handleSearch = async () => {
     const encText = encodeURIComponent(query); // 올바른 URL 인코딩을 위해 변수에서 함수로 수정
@@ -36,6 +38,17 @@ export default function Header({ type }) {
     }
   };
 
+  useEffect(() => {
+    const handleScroll = () => {
+      setScrolling(window.scrollY > 50);
+    };
+
+    window.addEventListener('scroll', handleScroll);
+
+    return () => {
+      window.removeEventListener('scroll', handleScroll);
+    };
+  }, []);
   switch (type) {
     case 'home':
       return (
@@ -60,7 +73,7 @@ export default function Header({ type }) {
       );
     case 'search':
       return (
-        <HeaderContainer type={type}>
+        <HeaderContainer type={type} scrolling={scrolling}>
           <Link to="/">🦁개발왕 아기사자🦁</Link>
           <li>
             <Link to="/">Home</Link>
@@ -79,7 +92,7 @@ export default function Header({ type }) {
       );
     case 'programming':
       return (
-        <HeaderContainer type={type}>
+        <HeaderContainer type={type} scrolling={scrolling}>
           <Link to="/">🦁개발왕 아기사자🦁</Link>
           <li>
             <Link to="/">Home</Link>

--- a/src/Components/Header/header.styled.jsx
+++ b/src/Components/Header/header.styled.jsx
@@ -5,16 +5,22 @@ export const HeaderContainer = styled.header`
   padding-left: 50px;
   padding-right: 50px;
   height: 100px;
-  flex-shrink: 0;
   display: flex;
   gap: 50px;
-  // justify-content: space-between;
   align-items: center;
   list-style: none;
   font-size: 18px;
-
   border-bottom: 1px solid #bdbdbd;
+  width: 100%;
+  position: fixed;
+  top: 0;
+  transition: transform 0.5s ease;
 
+  ${({ scrolling }) =>
+    scrolling &&
+    css`
+      transform: translateY(-100%);
+    `}
   ${props => {
     switch (props.type) {
       case 'home':

--- a/src/Pages/Home/HomePage.jsx
+++ b/src/Pages/Home/HomePage.jsx
@@ -6,7 +6,12 @@ import Header from '../../Components/Header/Header';
 import Footer from '../../Components/Footer/Footer';
 import SearchBar from '../../Components/SearchBar/SearchBar';
 import Info from '../../Components/Info/Info';
-import { StyledHomeLayout, StyledTitle, StyledError } from './home.styled';
+import {
+  StyledHomeLayout,
+  RootContainer,
+  StyledTitle,
+  StyledError,
+} from './home.styled';
 
 export default function HomePage() {
   const [query, setQuery] = useState('');
@@ -48,18 +53,20 @@ export default function HomePage() {
 
   return (
     <>
-      <Header type="home" />
-      <StyledHomeLayout>
-        <StyledTitle>🦁개발왕 아기사자🦁</StyledTitle>
-        <SearchBar
-          query={query}
-          setQuery={setQuery}
-          handleSearch={handleSearch}
-        />
-        {error && <StyledError>{error}</StyledError>}
-        <Info />
-      </StyledHomeLayout>
-      <Footer />
+      <RootContainer>
+        <Header type="home" />
+        <StyledHomeLayout>
+          <StyledTitle>🦁개발왕 아기사자🦁</StyledTitle>
+          <SearchBar
+            query={query}
+            setQuery={setQuery}
+            handleSearch={handleSearch}
+          />
+          {error && <StyledError>{error}</StyledError>}
+          <Info />
+        </StyledHomeLayout>
+        <Footer />
+      </RootContainer>
     </>
   );
 }

--- a/src/Pages/Home/home.styled.js
+++ b/src/Pages/Home/home.styled.js
@@ -7,6 +7,15 @@ export const StyledHomeLayout = styled.div`
   align-items: center;
   gap: 50px;
 
+  // height: 100vh;
+`;
+export const RootContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  // align-items: center;
+  // gap: 50px;
+
   height: 100vh;
 `;
 

--- a/src/Pages/Programming/ProgrammingPage.jsx
+++ b/src/Pages/Programming/ProgrammingPage.jsx
@@ -14,7 +14,6 @@ export default function ProgrammingPage() {
     <>
       <Header type="programming" />
       <StyledProgrammingLayout>
-        <p>Programming</p>
         <StyledProgramminContainer>
           <ProgrammingCard
             name={'JavaScript'}
@@ -216,7 +215,7 @@ export default function ProgrammingPage() {
           />
         </StyledProgramminContainer>
       </StyledProgrammingLayout>
-      <Footer />
+      {/* <Footer /> */}
     </>
   );
 }

--- a/src/Pages/Programming/programming.styled.js
+++ b/src/Pages/Programming/programming.styled.js
@@ -5,14 +5,14 @@ export const StyledProgrammingLayout = styled.div`
   flex-direction: column;
   justify-content: center;
   align-items: center;
-
-  // height: 100vh;
 `;
 
 export const StyledProgramminContainer = styled.div`
+  padding: 50px;
+  padding-top: 150px;
+  // padding-bottom: 150px;
   display: flex;
   flex-wrap: wrap;
-  gap: 60px;
+  gap: 50px;
   justify-content: center;
-  // overflow: auto;
 `;

--- a/src/Pages/Search/SearchPage.jsx
+++ b/src/Pages/Search/SearchPage.jsx
@@ -22,7 +22,7 @@ export default function SearchPage() {
           ))}
         </SearchResultLayOut>
       )}
-      <Footer />
+      {/* <Footer /> */}
     </div>
   );
 }


### PR DESCRIPTION
1. programming page, search page 아래로 스크롤하면  header 위로 올라가도록 구현
2. 전체 레이아웃 컴포넌트 추가하여 페이지에 header와 footer가 모두 눈에 들어오도록 변경
3. !도전적 시도 -> homepage를 제외한 programming, searchPage에서 footer 제거
(programmingPage layout은 수정하였으나, searchPage layout은 충돌우려로 변경하지않음)